### PR TITLE
Show formatted dates as comments.

### DIFF
--- a/WebContent/jsonview.css
+++ b/WebContent/jsonview.css
@@ -23,6 +23,10 @@ body {
   color: green;
 }
 
+.type-date {
+  color: gray;
+}
+
 .callback-function {
   color: gray;
 }

--- a/WebContent/workerFormatter.js
+++ b/WebContent/workerFormatter.js
@@ -12,8 +12,22 @@ function decorateWithSpan(value, className) {
 	return '<span class="' + className + '">' + htmlEncode(value) + '</span>';
 }
 
+function maybeDate(value) {
+	var valueType = typeof value;
+	if (valueType == "number") {
+		if (value > 946684800 && value < 2145916800)
+			return new Date(value * 1000);
+		else if (value > 946684800000 && value < 2145916800000)
+			return new Date(value);
+	} else if (valueType == "string") {
+		if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/.test(value))
+			return new Date(value);
+	}
+	return false;
+}
+
 function valueToHTML(value) {
-	var valueType = typeof value, output = "";
+	var valueType = typeof value, output = "", asDate = maybeDate(value);
 	if (value == null)
 		output += decorateWithSpan("null", "type-null");
 	else if (value && value.constructor == Array)
@@ -30,6 +44,9 @@ function valueToHTML(value) {
 	else if (valueType == "boolean")
 		output += decorateWithSpan(value, "type-boolean");
 
+	if ( asDate ){
+		output +=  ' <span class="type-date">/* [<b>' + asDate.toUTCString() + '</b>], [<b>' + asDate.toLocaleString() + '</b>] */</span>';
+	}
 	return output;
 }
 


### PR DESCRIPTION
I try to guess that a value is a Date:
   * Numbers that look like seconds or millis between Jan 1 2000 and Jan 1 2038
   * Strings that look like they came from JSON.stringify({'now': new Date()})
and then include GMT and Locale formatted versions, as comments, in the formatted JSON.

I realize that the comment is not valid JSON, but it's not too far off, a user could likely still copy & paste the formatted output into most things.

![image](https://cloud.githubusercontent.com/assets/1305026/5681935/9be59eb8-97ea-11e4-9877-290d3840d39c.png)